### PR TITLE
set explicit stringsAsFactors to pass on R<4

### DIFF
--- a/inst/tinytest/test_exemplar.R
+++ b/inst/tinytest/test_exemplar.R
@@ -4,11 +4,12 @@ df1 <- data.frame(
   y = sample(letters[1L:3L], size = 100, replace = TRUE,
              prob = c(0.1, 0.1, 0.8)),
   z = sample(c(Sys.Date(), Sys.Date() + 1, Sys.Date() + 2), size = 100,
-             replace = TRUE, prob = c(0.1, 0.1, 0.8))
+             replace = TRUE, prob = c(0.1, 0.1, 0.8)),
+  stringsAsFactors = FALSE
 )
 
 # Data frame that pdp::exemplar() should return
-df2 <- data.frame(x = 3L, y = "c", z = Sys.Date() + 2)
+df2 <- data.frame(x = 3L, y = "c", z = Sys.Date() + 2, stringsAsFactors = FALSE)
 
 # Expectation(s)
 df3 <- exemplar(df1)


### PR DESCRIPTION
Stated R dependency is 3.6, under which this test fails unless we specify an exact requirement.

Alternatively, we could try to ensure that the output works for inputs with `factor` columns, but that would require a deeper dive.

https://github.com/bgreenwell/pdp/blob/4f22141faf57d7e53761574067f2924aceb88e0f/DESCRIPTION#L15